### PR TITLE
add EXPOSE port command in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,5 +31,6 @@ COPY ./config/sql/ ./config/sql/
 COPY ./locales/ ./locales/
 COPY --from=builder /invidious/invidious .
 
+EXPOSE 3000
 USER invidious
 CMD [ "/invidious/invidious" ]


### PR DESCRIPTION
added EXPOSE (see https://docs.docker.com/engine/reference/builder/#expose) in the Dockerfile. With this the reverse proxy Traefik can detect the port automatically.